### PR TITLE
Cleanup stupid subclass logic

### DIFF
--- a/modules/core/Game.py
+++ b/modules/core/Game.py
@@ -19,11 +19,9 @@ class Game(namedtuple('Game', ['id', 'pgn', 'emts'])):
   def emtMean(self):
     return np.mean(self.emtsNoOutliers())
 
-  def __new__(cls, *args, **kvargs):
-    self = super().__new__(cls, *args, **kvargs)
+  def __init__(self, *args, **kvargs):
     self.mean = np.mean(self.emts)
     self.outlierCutoff = 0.5 * np.std(self.emts)
-    return self
 
 
 class GameBSONHandler:


### PR DESCRIPTION
namedtuple gets the arguments via it's `__new__`
method, so we do not have to call any super methods
from init.